### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # PostgreSQL
+[![smithery badge](https://smithery.ai/badge/@vinsidious/mcp-pg-schema)](https://smithery.ai/protocol_exists/@vinsidious/mcp-pg-schema)
 
 A Model Context Protocol server that provides read-only access to PostgreSQL databases. This server enables LLMs to inspect database schemas and execute read-only queries.
 
@@ -23,6 +24,14 @@ The server provides schema information for each table in the database:
 ## Usage with Claude Desktop
 
 To use this server with the Claude Desktop app, add the following configuration to the "mcpServers" section of your `claude_desktop_config.json`:
+
+### Installing via Smithery
+
+To install PostgreSQL Read-Only Server for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol_exists/@vinsidious/mcp-pg-schema):
+
+```bash
+npx -y @smithery/cli install @vinsidious/mcp-pg-schema --client claude
+```
 
 ### Docker
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,18 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - postgresUrl
+    properties:
+      postgresUrl:
+        type: string
+        description: The PostgreSQL connection URL, e.g.,
+          postgresql://user:password@host:port/db-name
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({command: 'node', args: ['dist/index.js', config.postgresUrl]})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@vinsidious/mcp-pg-schema?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂